### PR TITLE
Fix build with recent gnu-efi; update Dockerfile to stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 WORKDIR /build
 

--- a/apple_set_os.c
+++ b/apple_set_os.c
@@ -4,6 +4,7 @@
 #include <efidef.h>
 #include <efidevp.h>
 #include <eficon.h>
+#include <efiprot.h>
 #include <efiapi.h>
 #include <efierr.h>
 


### PR DESCRIPTION
Hello,

noticed a build failure in stretch and later (using gnu-efi 3.0.4).

Regards
Simon