### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ cp apple_set_os.efi /boot/efi/EFI/custom
 
 Grub can be configured to start apple_set_os.efi automatically by adding the following lines to  ``/etc/grub.d/40_custom``:
 ```
-search --no-floppy --set=root --label EFI
-chainloader (${root})/EFI/custom/apple_set_os.efi
+search --no-floppy --set=chain_root --label EFI
+chainloader (${chain_root})/EFI/custom/apple_set_os.efi
 boot
 ```
 


### PR DESCRIPTION
The instructions to start apple_set_os.efi by grub automatically used the variable 'root'. Many distributions already set this variable. By reusing the variable, grub no longer boots after the chainloader did its job. Introducing a new variable solves this